### PR TITLE
(fix) Security scanning, Chart Tooltip component, HTML content provision, Safe construction fixed

### DIFF
--- a/ui-client/packages/core/src/utils/chart-tooltip.ts
+++ b/ui-client/packages/core/src/utils/chart-tooltip.ts
@@ -141,15 +141,21 @@ export const buildChartTooltip = (
       return
     }
 
-    let innerHtml = '<div style="display: flex; flex-direction: column; gap: 8px;">'
+    const wrapper = document.createElement('div')
+
+    wrapper.style.display = 'flex'
+    wrapper.style.flexDirection = 'column'
+    wrapper.style.gap = '8px'
 
     if (showTitle && tooltip.title?.length) {
-      const titleText = tooltip.title.join(' ')
-      innerHtml += `<div style="
-        font-size: ${fontSize - 2}px;
-        color: ${COLOR.WHITE_ALPHA_05};
-        opacity: 0.7;
-      ">${titleText}</div>`
+      const titleEl = document.createElement('div')
+
+      titleEl.style.fontSize = `${fontSize - 2}px`
+      titleEl.style.color = COLOR.WHITE_ALPHA_05
+      titleEl.style.opacity = '0.7'
+      titleEl.textContent = tooltip.title.join(' ')
+
+      wrapper.appendChild(titleEl)
     }
 
     const bodyItems = tooltip.dataPoints ?? []
@@ -167,21 +173,35 @@ export const buildChartTooltip = (
         ? valueFormatter(Number(rawValue), item)
         : String(rawValue)
 
-      innerHtml += `<div style="
-        display: flex;
-        justify-content: space-between;
-        align-items: baseline;
-        font-size: ${fontSize}px;
-        line-height: ${fontSize + 4}px;
-        gap: 16px;
-      ">
-        <span style="color: ${resolvedLabelColor}; white-space: nowrap;">${label}</span>
-        <span style="color: ${resolvedValueColor}; white-space: nowrap; font-weight: 600;">${formattedValue}</span>
-      </div>`
+      const row = document.createElement('div')
+
+      row.style.display = 'flex'
+      row.style.justifyContent = 'space-between'
+      row.style.alignItems = 'baseline'
+      row.style.fontSize = `${fontSize}px`
+      row.style.lineHeight = `${fontSize + 4}px`
+      row.style.gap = '16px'
+
+      const labelSpan = document.createElement('span')
+
+      labelSpan.style.color = resolvedLabelColor
+      labelSpan.style.whiteSpace = 'nowrap'
+      labelSpan.textContent = String(label)
+
+      const valueSpan = document.createElement('span')
+
+      valueSpan.style.color = resolvedValueColor
+      valueSpan.style.whiteSpace = 'nowrap'
+      valueSpan.style.fontWeight = '600'
+      valueSpan.textContent = formattedValue
+
+      row.appendChild(labelSpan)
+      row.appendChild(valueSpan)
+
+      wrapper.appendChild(row)
     }
 
-    innerHtml += '</div>'
-    tooltipEl.innerHTML = innerHtml
+    tooltipEl.replaceChildren(wrapper)
 
     Object.assign(tooltipEl.style, {
       opacity: '1',

--- a/ui-client/packages/core/src/utils/specs/chart-tooltip.test.ts
+++ b/ui-client/packages/core/src/utils/specs/chart-tooltip.test.ts
@@ -178,7 +178,8 @@ describe('buildChartTooltip', () => {
     externalHandler({ chart: mockChart as any, tooltip: mockTooltipModel as any })
 
     const tooltipEl = mockContainer.querySelector('[data-msdk-chart-tooltip]')
-    expect(tooltipEl?.innerHTML).toContain('#FF00FF')
+    const labelSpan = tooltipEl?.querySelector<HTMLSpanElement>('span')
+    expect(labelSpan?.style.color).toBe('rgb(255, 0, 255)')
 
     document.body.removeChild(mockContainer)
   })
@@ -214,7 +215,8 @@ describe('buildChartTooltip', () => {
     externalHandler({ chart: mockChart as any, tooltip: mockTooltipModel as any })
 
     const tooltipEl = mockContainer.querySelector('[data-msdk-chart-tooltip]')
-    expect(tooltipEl?.innerHTML).toContain('#111111')
+    const valueSpan = tooltipEl?.querySelectorAll<HTMLSpanElement>('span')[1]
+    expect(valueSpan?.style.color).toBe('rgb(17, 17, 17)')
 
     document.body.removeChild(mockContainer)
   })
@@ -384,7 +386,8 @@ describe('buildChartTooltip', () => {
     })
 
     const tooltipEl = container.querySelector('[data-msdk-chart-tooltip]')
-    expect(tooltipEl?.innerHTML).toContain('#888')
+    const labelSpan = tooltipEl?.querySelector<HTMLSpanElement>('span')
+    expect(labelSpan?.style.color).toBe('rgb(136, 136, 136)')
 
     document.body.removeChild(container)
   })


### PR DESCRIPTION
**Description**:
Fixed `safe` construction for `html` content provision of `chart tooltip` component per `security` scanning.