### PR TITLE
Docs/msdk 148 review docs pages

### DIFF
--- a/.github/workflows/core.yaml
+++ b/.github/workflows/core.yaml
@@ -1,6 +1,11 @@
 name: MDK Core CI
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "core/**"
+      - ".github/workflows/core.yaml"
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize]
@@ -21,6 +26,7 @@ env:
 jobs:
   dependency-review:
     name: Dependency Review
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -1,6 +1,11 @@
 name: MDK UI CI
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "ui-client/**"
+      - ".github/workflows/ui.yaml"
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize]
@@ -22,6 +27,7 @@ env:
 jobs:
   dependency-review:
     name: Dependency Review
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - Collecting telemetry and operational data  
 - Building custom mining applications and integrations  
 
-MDK is released under [Apache License Version 2.0](LICENSE)
+MDK is released under [Apache License Version 2.0](LICENSE).
 
 ## Status
 
@@ -45,6 +45,8 @@ Learn more about [contributing](CONTRIBUTING.md).
 
 For security vulnerability reporting, see the [Security policy](SECURITY.md).
 
-## Documentation 
+## Documentation
 
-End user documentation is available at [docs.mdk.tether.io/](https://docs.mdk.tether.io/).
+End-user documentation is available at [docs.mdk.tether.io/](https://docs.mdk.tether.io/).
+> Request updates to public docs via[`docs-needed` issue](https://github.com/tetherto/mdk/issues/new?template=docs-needed.yml).
+Update documentation in this repository directly via the [contribution flow](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MDK
 
-[![Status](https://img.shields.io/badge/status-beta-orange?style=flat-square)](#status)
+[![Status](https://img.shields.io/badge/status-pre--alpha-lightgrey?style=flat-square)](#status)
 [![MDK UI CI](https://img.shields.io/github/actions/workflow/status/tetherto/mdk/ui.yaml?branch=main&label=UI%20CI&style=flat-square&logo=github)](https://github.com/tetherto/mdk/actions/workflows/ui.yaml)
 [![MDK Core CI](https://img.shields.io/github/actions/workflow/status/tetherto/mdk/core.yaml?branch=main&label=Core%20CI&style=flat-square&logo=github)](https://github.com/tetherto/mdk/actions/workflows/core.yaml)
 [![Documentation](https://img.shields.io/badge/docs-mdk.tether.io-2ea44f?style=flat-square)](https://docs.mdk.tether.io)


### PR DESCRIPTION
cursor solution: trigger UI and Core CI on push to main so README badges work
Both workflows previously ran on pull_request only, so every run was
attributed to a PR's source branch and shields.io found nothing on
main — the badges rendered "repo or workflow not found".
- Add push:[main] with the same paths filter as the existing pull_request
  trigger, so docs-only commits stay skipped.
- Gate the dependency-review job with
  `if: github.event_name == 'pull_request'` — actions/dependency-review-action
  requires PR context and would fail on push events.
First merge of this PR touches both workflow files (in the paths filter),
so both badges go live at the merge commit.