### PR TITLE
fix(foundation-ui): include all component styles in dist/styles.css

### DIFF
--- a/ui-client/packages/foundation/src/components/domain/alarm/styles.scss
+++ b/ui-client/packages/foundation/src/components/domain/alarm/styles.scss
@@ -1,0 +1,2 @@
+@forward './alarm-contents/alarm-contents.scss';
+@forward './alarm-row/alarm-row.scss';

--- a/ui-client/packages/foundation/src/components/domain/alerts/styles.scss
+++ b/ui-client/packages/foundation/src/components/domain/alerts/styles.scss
@@ -1,0 +1,3 @@
+@forward './alerts-table-title/alerts-table-title.scss';
+@forward './current-alerts/alert-confirmation-modal/alert-confirmation-modal.scss';
+@forward './tag-filter-bar/tag-filter-bar.scss';

--- a/ui-client/packages/foundation/src/components/domain/container-params-settings/styles.scss
+++ b/ui-client/packages/foundation/src/components/domain/container-params-settings/styles.scss
@@ -1,0 +1,3 @@
+@forward './base-status-indicator/base-status-indicator.scss';
+@forward './base-threshold-form.scss';
+@forward './container-params-settings.scss';

--- a/ui-client/packages/foundation/src/components/domain/container/styles.scss
+++ b/ui-client/packages/foundation/src/components/domain/container/styles.scss
@@ -1,0 +1,13 @@
+@forward './bitmain-immersion-summary-box/bitmain-immersion-summary-box.scss';
+@forward './container-charts/container-charts.scss';
+@forward './container-controls-box/container-controls-box.scss';
+@forward './content-box/content-box.scss';
+@forward './data-row/data-row.scss';
+@forward './enabled-disable-toggle/enabled-disable-toggle.scss';
+@forward './generic-data-box/generic-data-box.scss';
+@forward './micro-bt-widget-box/micro-bt-widget-box.scss';
+@forward './miners-summary-box/miners-summary-box.scss';
+@forward './socket/socket.scss';
+@forward './supply-liquid-box/supply-liquid-box.scss';
+@forward './system-status-control-box/system-status-control-box.scss';
+@forward './tanks-box/tanks-box.scss';

--- a/ui-client/packages/foundation/src/components/domain/dashboard/styles.scss
+++ b/ui-client/packages/foundation/src/components/domain/dashboard/styles.scss
@@ -1,0 +1,1 @@
+@forward './hash-rate-line-chart/hash-rate-line-chart-with-pool/hash-rate-line-chart-with-pool.scss';

--- a/ui-client/packages/foundation/src/components/domain/explorer/styles.scss
+++ b/ui-client/packages/foundation/src/components/domain/explorer/styles.scss
@@ -1,0 +1,55 @@
+// Bitdeer container settings
+@forward './containers/bitdeer/settings/bitdeer-settings.scss';
+@forward './containers/bitdeer/settings/container-options/bitdeer-options.scss';
+@forward './containers/bitdeer/settings/container-options/bitdeer-pumps.scss';
+@forward './containers/bitdeer/settings/container-options/dry-cooler/container-fans-card/container-fans-card.scss';
+@forward './containers/bitdeer/settings/container-options/dry-cooler/container-fans-card/container-fans-legend.scss';
+@forward './containers/bitdeer/settings/container-options/dry-cooler/dry-cooler.scss';
+@forward './containers/bitdeer/settings/container-options/pump-box/pump-box.scss';
+
+// Bitmain immersion
+@forward './containers/bitmain-immersion/control-box/bitmain-immersion-control-box.scss';
+@forward './containers/bitmain-immersion/controls-tab/bitmain-immersion-controls-tab.scss';
+@forward './containers/bitmain-immersion/pump-station/bitmain-immersion-pump-station-control-box.scss';
+@forward './containers/bitmain-immersion/system-status/bitmain-immersion-system-status.scss';
+@forward './containers/bitmain-immersion/unit-control-box/bitmain-immersion-compact-unit-control-box.scss';
+@forward './containers/bitmain-immersion/unit-control-box/bitmain-immersion-unit-control-box.scss';
+
+// Bitmain
+@forward './containers/bitmain/bitmain-hydro-settings.scss';
+@forward './containers/bitmain/status-item/settings/bitmain-basic-settings.scss';
+@forward './containers/bitmain/status-item/settings/cooling-system/bitmain-cooling-system.scss';
+@forward './containers/bitmain/status-item/settings/power-and-positioning/bitmain-power-and-positioning.scss';
+@forward './containers/bitmain/status-item/status-item.scss';
+
+// Micro BT
+@forward './containers/micro-bt/cooling/micro-bt-cooling.scss';
+@forward './containers/micro-bt/fire-status-box/fire-status-box.scss';
+@forward './containers/micro-bt/gauge-chart/gauge-chart-component.scss';
+@forward './containers/micro-bt/power-meters/power-meters.scss';
+@forward './containers/micro-bt/settings/micro-bt-settings.scss';
+
+// Details view
+@forward './details-view/batch-container-controls-card/batch-container-controls-card.scss';
+@forward './details-view/container-controls-card/container-controls-card.scss';
+@forward './details-view/miner-chips-card/miner-chip/miner-chip.scss';
+@forward './details-view/miner-chips-card/miner-chips-card.scss';
+@forward './details-view/miner-controls-card/miner-controls-card.scss';
+@forward './details-view/miner-info-card/miner-info-card.scss';
+@forward './details-view/miner-metric-card/miner-metric-card.scss';
+@forward './details-view/miner-power-mode-selection-buttons/miner-power-mode-selection-buttons.scss';
+@forward './details-view/miner-power-mode-selection-buttons/power-mode-selection-dropdown.scss';
+@forward './details-view/miners-activity-chart/miners-activity-chart.scss';
+@forward './details-view/secondary-stat-card/secondary-stat-card.scss';
+@forward './details-view/single-stat-card/single-stat-card.scss';
+@forward './details-view/stats-group-card/stats-group-card.scss';
+
+// Dialogs
+@forward './dialogs/add-replace-miner-dialog/add-replace-miner-dialog-content.scss';
+@forward './dialogs/position-change-dialog/confirm-change-position-dialog/confirm-change-position-dialog-content.scss';
+@forward './dialogs/position-change-dialog/container-selection-dialog-content/container-selection-dialog-content.scss';
+@forward './dialogs/position-change-dialog/default-position-change-dialog-content/default-position-change-dialog-content.scss';
+@forward './dialogs/position-change-dialog/maintenance-dialog-content/maintenance-dialog-content.scss';
+@forward './dialogs/position-change-dialog/position-change-dialog.scss';
+@forward './dialogs/position-change-dialog/rack-id-selection-dropdown/rack-id-selection-dropdown.scss';
+@forward './dialogs/position-change-dialog/static-miner-ip-assigment/static-miner-ip-assigment.scss';

--- a/ui-client/packages/foundation/src/components/domain/info-container/styles.scss
+++ b/ui-client/packages/foundation/src/components/domain/info-container/styles.scss
@@ -1,0 +1,1 @@
+@forward './info-container.scss';

--- a/ui-client/packages/foundation/src/components/domain/pool-manager/styles.scss
+++ b/ui-client/packages/foundation/src/components/domain/pool-manager/styles.scss
@@ -1,0 +1,6 @@
+@forward './assign-pool-modal/assign-pool-modal.scss';
+@forward './dashboard/styles.scss';
+@forward './miner-explorer/styles.scss';
+@forward './pools/add-pool-modal/add-pool-modal.scss';
+@forward './pools/pool-collapse-item-body/pool-collapse-item-body.scss';
+@forward './pools/pool-collapse-item-header/pool-collapse-item-header.scss';

--- a/ui-client/packages/foundation/src/components/domain/settings/add-user-modal/add-user-modal.scss
+++ b/ui-client/packages/foundation/src/components/domain/settings/add-user-modal/add-user-modal.scss
@@ -1,3 +1,5 @@
+@use '@tetherto/mdk-core-ui/styles' as *;
+
 .mdk-settings-add-user-modal {
   &__form {
     @include flex_column;

--- a/ui-client/packages/foundation/src/components/domain/settings/feature-flags/feature-flags-settings.scss
+++ b/ui-client/packages/foundation/src/components/domain/settings/feature-flags/feature-flags-settings.scss
@@ -1,3 +1,5 @@
+@use '@tetherto/mdk-core-ui/styles' as *;
+
 .mdk-settings-feature-flags {
   padding: 20px;
 

--- a/ui-client/packages/foundation/src/components/domain/settings/header-controls/header-controls-settings.scss
+++ b/ui-client/packages/foundation/src/components/domain/settings/header-controls/header-controls-settings.scss
@@ -1,3 +1,5 @@
+@use '@tetherto/mdk-core-ui/styles' as *;
+
 .mdk-settings-header-controls {
   @include flex_column;
 

--- a/ui-client/packages/foundation/src/components/domain/settings/import-export/import-export-settings.scss
+++ b/ui-client/packages/foundation/src/components/domain/settings/import-export/import-export-settings.scss
@@ -1,3 +1,5 @@
+@use '@tetherto/mdk-core-ui/styles' as *;
+
 .mdk-settings-import-export {
   @include flex_column;
 

--- a/ui-client/packages/foundation/src/components/domain/settings/manage-user-modal/manage-user-modal.scss
+++ b/ui-client/packages/foundation/src/components/domain/settings/manage-user-modal/manage-user-modal.scss
@@ -1,3 +1,5 @@
+@use '@tetherto/mdk-core-ui/styles' as *;
+
 .mdk-settings-manage-user {
   &__dialog {
     max-width: 600px;

--- a/ui-client/packages/foundation/src/components/domain/settings/rbac-control/rbac-control-settings.scss
+++ b/ui-client/packages/foundation/src/components/domain/settings/rbac-control/rbac-control-settings.scss
@@ -1,3 +1,5 @@
+@use '@tetherto/mdk-core-ui/styles' as *;
+
 .mdk-settings-rbac {
   @include flex_column;
 

--- a/ui-client/packages/foundation/src/components/domain/settings/settings-dashboard/settings-dashboard.scss
+++ b/ui-client/packages/foundation/src/components/domain/settings/settings-dashboard/settings-dashboard.scss
@@ -1,3 +1,5 @@
+@use '@tetherto/mdk-core-ui/styles' as *;
+
 .mdk-settings-dashboard {
   @include flex_column;
 

--- a/ui-client/packages/foundation/src/components/domain/settings/styles.scss
+++ b/ui-client/packages/foundation/src/components/domain/settings/styles.scss
@@ -1,0 +1,7 @@
+@forward './add-user-modal/add-user-modal.scss';
+@forward './feature-flags/feature-flags-settings.scss';
+@forward './header-controls/header-controls-settings.scss';
+@forward './import-export/import-export-settings.scss';
+@forward './manage-user-modal/manage-user-modal.scss';
+@forward './rbac-control/rbac-control-settings.scss';
+@forward './settings-dashboard/settings-dashboard.scss';

--- a/ui-client/packages/foundation/src/components/domain/timeline-chart/styles.scss
+++ b/ui-client/packages/foundation/src/components/domain/timeline-chart/styles.scss
@@ -1,0 +1,1 @@
+@forward './timeline-chart.scss';

--- a/ui-client/packages/foundation/src/components/feature/styles.scss
+++ b/ui-client/packages/foundation/src/components/feature/styles.scss
@@ -1,0 +1,3 @@
+@forward './features/alerts/alerts/alerts.scss';
+@forward './features/pool-manager/miner-explorer/pool-manager-miner-explorer.scss';
+@forward './features/pool-manager/pools/pool-manager-pools.scss';

--- a/ui-client/packages/foundation/src/styles/index.scss
+++ b/ui-client/packages/foundation/src/styles/index.scss
@@ -4,10 +4,24 @@
 
 // Domain Component Styles
 @forward '../components/domain/active-incidents-card/styles';
+@forward '../components/domain/alarm/styles';
+@forward '../components/domain/alerts/styles';
+@forward '../components/domain/chart-wrapper/styles';
+@forward '../components/domain/container/styles';
+@forward '../components/domain/container-charts-builder/styles';
+@forward '../components/domain/container-params-settings/styles';
+@forward '../components/domain/dashboard/styles';
+@forward '../components/domain/device-explorer/styles';
+@forward '../components/domain/explorer/styles';
+@forward '../components/domain/info-container/styles';
+@forward '../components/domain/line-chart-card/styles';
 @forward '../components/domain/pool-details-card/styles';
 @forward '../components/domain/pool-details-popover/styles';
-@forward '../components/domain//device-explorer/styles';
-@forward '../components/domain/chart-wrapper/styles';
+@forward '../components/domain/pool-manager/styles';
+@forward '../components/domain/settings/styles';
 @forward '../components/domain/stats-export/styles';
-@forward '../components/domain/container-charts-builder/styles';
-@forward '../components/domain/line-chart-card/styles';
+@forward '../components/domain/timeline-chart/styles';
+@forward '../components/domain/widget-top-row/styles';
+
+// Feature Component Styles
+@forward '../components/feature/styles';


### PR DESCRIPTION
## Summary

`packages/foundation/src/styles/index.scss` only `@forward`ed 8 of ~94 component stylesheets, so most components (SingleStatCard, MinerInfoCard, MinerControlsCard, all settings, pool-manager, the entire explorer subtree, alarm/alerts, container, etc.) shipped with no CSS in `dist/styles.css` and rendered unstyled for consumers.

The previously-stripped `import './foo.scss'` lines (removed by `scripts/postbuild.mjs`) assumed those styles were already in `dist/styles.css` — but Vite only compiles SCSS reachable from the single `src/styles/index.scss` entry, and most files weren't reachable.

## Changes

- Add 11 per-subtree barrel `styles.scss` files (`alarm`, `alerts`, `container`, `container-params-settings`, `dashboard`, `explorer`, `info-container`, `pool-manager`, `settings`, `timeline-chart` under `domain/`, plus one for `feature/`) that `@forward` their child stylesheets.
- Forward every barrel from `src/styles/index.scss` (alphabetised) and add `widget-top-row/styles` which was also missing.
- Add `@use '@tetherto/mdk-core-ui/styles' as *;` to the seven settings SCSS files that were relying on the demo's `additionalData` Vite injection (which doesn't run during the foundation library build) and would otherwise fail with "Undefined mixin".

## Verification

- `pnpm --filter @tetherto/mdk-foundation-ui build:scss` succeeds.
- `dist/styles.css` grows to ~76 KB (11.33 KB gzipped) with **609** unique `.mdk-*` class definitions.
- Per-file audit: 96 component SCSS files, 0 missing classes in the bundle.
- Previously-broken classes confirmed present: `.mdk-single-stat-card`, `.mdk-miner-info-card`, `.mdk-miner-controls`, `.mdk-settings-dashboard`, `.mdk-pm-dashboard`, `.mdk-pm-add-pool-modal`, `.mdk-bitmain-immersion-control-box`, `.mdk-content-box`, `.mdk-data-row`, `.mdk-alerts-tag-filter-bar`, `.mdk-pm-pool-body`, `.mdk-timeline-chart`, `.mdk-info-container`, etc.

## Test plan

- [x] Pull this branch and run `pnpm build` from a clean checkout.
- [x] In a downstream consumer, import `@tetherto/mdk-foundation-ui/styles.css` and confirm previously-unstyled components (SingleStatCard, MinerInfoCard, settings dashboard, pool-manager pieces) now render with proper styling.
- [x] Run `pnpm test` — coverage threshold (94%) should still pass.
- [x] Run `pnpm dev:demo` and visually confirm no regressions on already-styled components.