### PR TITLE
chore: Add RELEASE_NOTES/0.0.1-pre-alpha

### DIFF
--- a/RELEASE_NOTES/0.0.1-pre-alpha.md
+++ b/RELEASE_NOTES/0.0.1-pre-alpha.md
@@ -1,0 +1,128 @@
+# Release v0.0.1
+
+Released: 27 April 2026
+
+## Overview
+
+MDK v0.0.1 is the first public release of the Mining Development Kit — an open, modular infrastructure layer for mining operations. This release establishes
+the MDK architecture and ships the UI Dev Kit as the first production-grade building block so frontend teams can start building consistent bitcoin mining
+management interfaces today.
+
+MDK aims to become the standard open infrastructure layer for mining operations, enabling:
+
+- Interoperable tools across vendors
+- Faster development cycles
+- AI-native mining operations
+- A shared ecosystem instead of fragmented proprietary stacks
+
+v0.0.1 is for early adopters who want to evaluate MDK's architecture, build mining dashboards on top of the UI Dev Kit, and become part of the core community
+that will shape the direction of the stack. **ORK** (`@tetherto/mdk-ork`) lands its first reference worker footprint here; the CLI and end-to-end developer workflows arrive
+in v0.0.2–v0.0.3.
+
+### Next release priorities
+
+- First working version of **ORK** (engine / orchestrator)
+- CLI/developer entry points
+- MDK protocol
+- Device library templates
+
+Learn more from the [roadmap](https://docs.mdk.tether.io/resources/roadmap/).
+
+> This early release is intended to give our community an opportunity to present feedback and contribute to the direction MDK takes:
+> **Feedback wanted**:
+> - Is the MDK architecture clear and coherent?
+> - What’s missing to make MDK useful for building solid mining software?
+> - Are there gaps in device abstraction model and/or integration flows?
+> **Contributions welcomed**:
+> - MDK stack architecture
+> - New device libraries
+> - Protocol and communication layer design
+> - CLI / developer tooling proposals
+> - UI components
+
+Understand how to [contribute](../CONTRIBUTING.md)
+
+### Highlights
+
+This is the first public release of MDK: open, modular toolkit for mining operations dashboards and management interfaces.
+
+**`@tetherto/mdk-react-devkit`** — Radix-based component library: accessible, composable primitives styled via SCSS with zero CSS-in-JS runtime overhead (v0.0.1: **`@tetherto/mdk-core-ui`**, `ui-client/packages/core`).
+
+**`@tetherto/mdk-foundation-ui`** — mining-domain layer above those primitives (v0.0.1: `ui-client/packages/foundation`).
+
+- **UI Dev Kit ready for production use** today: 200+ components across primitives and domain layers.
+- **ORK** (`@tetherto/mdk-ork`) introduced with device-connectivity and data-storage interfaces, plus the canonical reference worker line (v0.0.1 publish scopes in parentheses):
+  - **`@tetherto/mdk-worker-base`** (v0.0.1: no **`@tetherto/mdk-worker-base`** package; worker scaffolds ship as **`@tetherto/tpl-lib-*`** and related core packages)
+  - **`@tetherto/mdk-worker-whatsminer`** (v0.0.1: **`@tetherto/miner-whatsminer`**)
+  - **`@tetherto/mdk-worker-antminer`** (v0.0.1: **`@tetherto/miner-antminer`**)
+  - **`@tetherto/mdk-worker-avalon`** (v0.0.1: **`@tetherto/miner-avalon`**)
+  - **`@tetherto/mdk-worker-antspace`** (v0.0.1: **`@tetherto/container-antspace`**)
+  - **`@tetherto/mdk-worker-temperature-generic`** (v0.0.1: **`@tetherto/sensor-temp-seneca`**)
+  - **`@tetherto/mdk-worker-power-meter-seneca`** (v0.0.1: **`@tetherto/powermeter-abb`**, **`@tetherto/powermeter-schneider`**, **`@tetherto/powermeter-satec`** — architecture-facing power-meter scope; no Seneca-branded power-meter package in this tag)
+- Test coverage thresholds enforced: ≥ 80%.
+
+### Additions and improvements
+
+ORK **`@tetherto/mdk-ork`** — first reference worker footprint:
+
+- Mining hardware: **`@tetherto/mdk-worker-whatsminer`** (v0.0.1: **`@tetherto/miner-whatsminer`**), **`@tetherto/mdk-worker-antminer`** (v0.0.1: **`@tetherto/miner-antminer`**), **`@tetherto/mdk-worker-avalon`** (v0.0.1: **`@tetherto/miner-avalon`**)
+- Containerised infrastructure: **`@tetherto/mdk-worker-antspace`** (v0.0.1: **`@tetherto/container-antspace`**)
+- Power metering: **`@tetherto/mdk-worker-power-meter-seneca`** (v0.0.1: **`@tetherto/powermeter-abb`**, **`@tetherto/powermeter-schneider`**, **`@tetherto/powermeter-satec`**)
+- Temperature sensing: **`@tetherto/mdk-worker-temperature-generic`** (v0.0.1: **`@tetherto/sensor-temp-seneca`**)
+- Shared worker SDK: **`@tetherto/mdk-worker-base`** (v0.0.1: not published; use **`@tetherto/tpl-lib-*`** and **`@tetherto/mdk-core`** workspace layout)
+- Unified device-connectivity interfaces and built-in structured data collection/storage.
+
+Learn more about [ORK](https://docs.mdk.tether.io/overview/architecture/ork/).
+
+**`@tetherto/mdk-react-devkit`** — primitive component library (Radix UI + SCSS, zero CSS-in-JS runtime) (v0.0.1: **`@tetherto/mdk-core-ui`**, `ui-client/packages/core`).
+
+- **`@tetherto/mdk-ui-core`** — headless browser client (telemetry, API client; no React) (v0.0.1: not a separate package; covered by **`@tetherto/mdk-core-ui`** in this tag).
+- **`@tetherto/mdk-react-adapter`** — thin React hooks and bindings on **`@tetherto/mdk-ui-core`** (v0.0.1: not a separate package; covered by **`@tetherto/mdk-core-ui`** in this tag).
+
+This release mainly ships **`@tetherto/mdk-react-devkit`** (v0.0.1: **`@tetherto/mdk-core-ui`**) and **`@tetherto/mdk-foundation-ui`**; **`@tetherto/mdk-ui-core`** and **`@tetherto/mdk-react-adapter`** name the architecture split ahead of that layout.
+
+- 58 component directories spanning forms (Button, Input, Form/FormFields, Cascader, ListViewFilter…), overlays (Dialog, AlertDialog, Popover, Tooltip, Toast, ActionButton…), layout (Accordion, Card, Tabs, Sidebar, Mosaic…), data display (Avatar, Badge, Indicator, Typography, NotFoundPage…), and loading states.
+- Feature-rich DataTable built on TanStack Table v8 (sort, select, expand, paginate).
+- 5 chart types — Area, Bar, Line, Doughnut, Gauge — with ChartContainer, ChartStatsFooter, and DetailLegend chrome.
+- 78 domain SVG icons (74 barrel-exported + 4 by direct import) via `createIcon` factory.
+- `--mdk-*` CSS custom-property token system with light/dark themes via `applyTheme` / `getSystemTheme` helpers.
+- 15 utility modules: `cn`, `format`, `number`, `date`, `time`, `color`, `array`, `async`, `string`, `validation`, chart helpers, `conversion`, `types`.
+- Form / FormFields system wrapping `react-hook-form` + Zod.
+
+**`@tetherto/mdk-foundation-ui`** — mining-domain layer above the primitives (v0.0.1: `ui-client/packages/foundation`).
+
+- ~143 domain components across 20+ feature areas: dashboard charts, device explorer, container panels (Bitmain Hydro, Bitmain Immersion, Bitdeer, Micro BT), miner detail view, settings, pool manager, timeline, alarms, widget chrome.
+- Redux Toolkit store with 5 slices: `auth`, `actions`, `devices`, `notifications`, `timezone`.
+- 12 exported public hooks (`useLocalStorage`, `usePagination`, `useNotification`, `useHasPerms`, `useCheckPerm`, `useBeepSound`, `useChartDataCheck`, `useHeaderControls`, `useIsFeatureEditingEnabled`, `useContextualModal`, `useListViewFilters`, `useTimezone`) plus 8 internal hooks.
+
+**`@tetherto/mdk-fonts`** — JetBrains Mono CSS font package, zero JS runtime (v0.0.1: **`@tetherto/mdk-fonts-ui`**, `ui-client/packages/fonts`).
+
+**Reference demo** — Vite + React app under `ui-client/apps/demo` (v0.0.1: **`@tetherto/mdk-demo-ui`**) covering every component across two top-level sections (core and foundation) with nested groups for forms, overlays, data display, charts, navigation, dashboard widgets, container types, alerts, pool manager, and settings.
+
+**Build system and tooling:**
+
+- pnpm v10 workspace with shared catalog for pinned dependency versions.
+- Turborepo v2 pipeline (`build`, `build:ts`, `build:scss`, `dev`, `lint`, `typecheck`, `test`).
+- Vite v7 in library mode; separate `build:ts` (tsc) and `build:scss` (Rollup + postcss + sass + autoprefixer) pipelines.
+- TypeScript 5 strict mode across all packages.
+- Vitest v4 with happy-dom; coverage thresholds 80% on **`@tetherto/mdk-react-devkit`** (v0.0.1: enforced on **`@tetherto/mdk-core-ui`**), 90% lines/statements + 80% branches/functions on **`@tetherto/mdk-foundation-ui`**.
+- ESLint + Prettier at workspace root.
+
+### Bug fixes
+
+NA: first release.
+
+### Breaking changes
+
+NA: first release.
+
+### Upgrade notes
+
+- No upgrade actions: this is the inaugural release.
+- **Peer dependencies:** React 18.3+, Node.js 20+, pnpm 10+.
+- **Package manager:** pnpm is required. npm and yarn are not yet supported by this monorepo.
+- **`@tetherto/mdk-foundation-ui`** components are consumed directly from source via a `workspace:*` dependency.
+
+### Downloads
+
+Clone [this repository](https://github.com/tetherto/mdk) and follow the [UI Kit readme](./ui-client/README.md).


### PR DESCRIPTION
docs: add v0.0.1 release notes with architecture vs workspace naming

Add RELEASE_NOTES/0.0.1-pre-alpha.md mapping canonical MDK names to v0.0.1
publish scopes and paths (ORK, workers, react-devkit/core-ui, foundation, fonts,
demo, FE stack note).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214241585314535