### PR TITLE
ci: stop node_modules cache restore-keys poisoning

### DIFF
--- a/.github/actions/node-setup-cache/action.yml
+++ b/.github/actions/node-setup-cache/action.yml
@@ -82,5 +82,3 @@ runs:
       with:
         path: ${{ steps.cache-keys.outputs.node-modules-path }}
         key: ${{ steps.cache-keys.outputs.cache-key }}
-        restore-keys: |
-          ${{ steps.cache-keys.outputs.base-key }}-


### PR DESCRIPTION
## Summary
- Remove `restore-keys` from the **save** step of `.github/actions/node-setup-cache`.

## Why
On a lockfile change the new exact cache key misses, `restore-keys` then matches the *previous* cache, and stale `node_modules` get restored over the fresh install and re-saved under the new key — so CI silently runs with outdated deps (this is what let a pinned vite bump keep resolving to the old major in PR #38).

Dropping `restore-keys` on the save path forces a clean install whenever the lockfile changes. The companion `node-restore-cache` action keeps its prefix fallback (read-only, safe speedup).

## Test plan
- [ ] On a PR that changes `package-lock.json`, confirm the cache key misses and a fresh `npm ci` runs (no stale restore).
- [ ] On a PR with no lockfile change, confirm the exact-key cache still hits.
